### PR TITLE
Test Ruby 3.0.0 with GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ 2.7.x, 3.0.x ]
+        ruby-version: [ 2.7.2, 3.0.0 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,15 +9,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: [ 2.7.x, 3.0.x ]
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby
+      - name: Set up Ruby ${{ matrix.ruby-version }}
         # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
         # change this to (see https://github.com/ruby/setup-ruby#versioning):
         # uses: ruby/setup-ruby@v1
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - name: Install dependencies
         run: bundle install

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 /spec/reports/
 /tmp/
 
+## IDE Specific
+# JetBrains IDE files:
 .idea
 
+## Other
+# Intended to be used as a library or gem that could run in multiple environments
 .ruby-version

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /tmp/
 
 .idea
+
+.ruby-version


### PR DESCRIPTION
Adds Ruby 3.0.0 (latest patch version) to GitHub Actions. Tests will now be run against Ruby versions 2.7.2 and 3.0.2.

I tried using the `x` wildcard in the docs in https://github.com/dvci/health_cards/pull/2/commits/037ca2229b18cb65228b0c34631ff8f9a06c3882 but it wasn't working so I changed it to explicitly list `2.7.2` instead of `2.7.x`. Would like to use the wildcard if anyone knows how to get it working.

[Testing with multiple versions of Ruby](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-ruby#testing-with-multiple-versions-of-ruby)
[Ruby 3.0.0 Release Notes](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/)