### PR TITLE
Fix Patient Updates and FHIR logging in Dev/Prod

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -19,7 +19,7 @@ class Patient < ApplicationRecord
   end
 
   before_validation do
-    self.json = fhir_patient.to_json
+    self.json = new_from_attributes.to_json
   end
 
   after_find do
@@ -41,11 +41,9 @@ class Patient < ApplicationRecord
   private
 
   def fhir_patient
-    @fhir_patient ||= if json
-                        FHIR.from_contents(json)
-                      else
-                        new_from_attributes
-                      end
+    return @patient if @patient && !has_changes_to_save?
+
+    @patient = FHIR.from_contents(json)
   end
 
   def new_from_attributes

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,3 +5,5 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+FHIR.logger.level = 1

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -30,6 +30,14 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to patient_url(new_patient)
   end
 
+  test 'should not create patient' do
+    assert_no_difference('Patient.count') do
+      post patients_url, params: { patient: { gender: 'foo' } }
+    end
+
+    assert_response :unprocessable_entity
+  end
+
   test 'should show patient' do
     get patient_url(@patient)
     assert_response :success
@@ -41,8 +49,20 @@ class PatientsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update patient' do
-    patch patient_url(@patient), params: { patient: { json: @patient.json } }
+    @attributes[:given] = 'baz'
+    patch patient_url(@patient), params: { patient: @attributes }
+
+    @patient.reload
+    assert_equal @attributes[:given], Patient.find(@patient.id).given
+
     assert_redirected_to patient_url(@patient)
+  end
+
+  test 'should not update patient' do
+    gender = 'NOT A VALID GENDER'
+    patch patient_url(@patient), params: { patient: { gender: gender } }
+    assert_not_equal gender, @patient.reload.gender
+    assert_response :unprocessable_entity
   end
 
   test 'should destroy patient' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -14,8 +14,15 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   test 'empty patient json serialization' do
-    p1 = Patient.create
-    assert p1.valid?, 'Empty patient is not valid'
-    Patient.find(p1.id)
+    patient = Patient.create
+    assert_not patient.new_record?
+  end
+
+  test 'update patient' do
+    patient = Patient.create
+    given = 'foo'
+    assert patient.update(given: given)
+    patient.reload
+    assert_equal given, patient.given
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,10 +11,6 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
 
-FHIR.logger.level = 1
-ActiveRecord::Base.logger.level = 1
-Rails.logger.level = 1
-
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
I noticed the patient controller test still had the scaffolded code that usePatient.json, so I updated the tests to use actual params. The tests didn't work because json serialization wasn't updating the json for existing Patients so I rewrote the serialization code.

I also moved the FHIR logger level to environment so it's not at debug level by default in any environment.