### PR TITLE
Meta special case

### DIFF
--- a/lib/health_cards/verifiable_credential.rb
+++ b/lib/health_cards/verifiable_credential.rb
@@ -89,7 +89,11 @@ module HealthCards
         resource = entry['resource']
         resource.delete('id')
         resource.delete('text')
-        resource['meta'] = resource['meta'].slice('security') if resource.key?('meta')
+        if resource.dig('meta', 'security')
+          resource['meta'] = resource['meta'].slice('security')
+        else
+          resource.delete('meta')
+        end
         update_nested_elements(resource)
       end
     end

--- a/lib/health_cards/verifiable_credential.rb
+++ b/lib/health_cards/verifiable_credential.rb
@@ -88,8 +88,8 @@ module HealthCards
       entries.each do |entry|
         resource = entry['resource']
         resource.delete('id')
-        resource.delete('meta')
         resource.delete('text')
+        resource['meta'] = resource['meta'].slice('security') if resource.key?('meta')
         update_nested_elements(resource)
       end
     end

--- a/test/fixtures/files/example-verbose-jws-payload.json
+++ b/test/fixtures/files/example-verbose-jws-payload.json
@@ -8,7 +8,12 @@
         "resourceType": "Patient",
         "id" : "Element",
         "meta" : {
-          "lastUpdated" : "2019-11-01T09:29:23.356+11:00"
+          "lastUpdated" : "2019-11-01T09:29:23.356+11:00",
+          "security" : [{
+            "system" : "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+            "code" : "DELAU",
+            "display" : "delete after use"
+          }]
         },
         "text" : {
           "status" : "generated",

--- a/test/health_cards/verifiable_credential_test.rb
+++ b/test/health_cards/verifiable_credential_test.rb
@@ -55,12 +55,14 @@ class VerifiableCredentialTest < ActiveSupport::TestCase
     @vc = HealthCards::VerifiableCredential.new(@verbose_bundle)
 
     stripped_bundle = @vc.strip_fhir_bundle
-    stripped_resources = stripped_bundle['entry']
+    stripped_entries = stripped_bundle['entry']
+    pp stripped_bundle
 
-    stripped_resources.each do |resource|
+    stripped_entries.each do |entry|
+      resource = entry['resource']
       assert_not(resource.key?('id'))
-      assert_not(resource.key?('meta'))
       assert_not(resource.key?('text'))
+      assert(!resource.key?('meta') || (resource.key?('meta') && (resource['meta'].keys == ['security'])))
     end
   end
 

--- a/test/health_cards/verifiable_credential_test.rb
+++ b/test/health_cards/verifiable_credential_test.rb
@@ -56,7 +56,6 @@ class VerifiableCredentialTest < ActiveSupport::TestCase
 
     stripped_bundle = @vc.strip_fhir_bundle
     stripped_entries = stripped_bundle['entry']
-    pp stripped_bundle
 
     stripped_entries.each do |entry|
       resource = entry['resource']


### PR DESCRIPTION
## Small change in the way bundle stripping is done, according to https://github.com/smart-on-fhir/health-cards/pull/117/files:

Resource.meta fields are now allowed to be included within FHIR bundles if they contain only a `security` element. 

This PR also fixes a bug in one of the VerifiableCredential tests where the test was not actually checking to see if the resource-level elements were removed (instead of checking if `Resource.text`, `Resource.meta`, and `Resource.id` were removed, it was doing this check one-level up, so it was only actually checking the `resource` and `fullUrl` fields of each Bundle entry.


