### PR TITLE
Better reference handling in Bundles

### DIFF
--- a/app/models/fhir_record.rb
+++ b/app/models/fhir_record.rb
@@ -6,6 +6,8 @@ class FHIRRecord < ApplicationRecord
 
   validate :valid_fhir_json
 
+  after_create :set_fhir_id
+
   def to_json(*_args)
     json.to_hash
   end
@@ -28,5 +30,10 @@ class FHIRRecord < ApplicationRecord
 
     err_msg = errs.map { |name, value| "#{name}: #{value}" }.join(', ')
     errors.add(:base, err_msg)
+  end
+
+  def set_fhir_id
+    json.id = id
+    save
   end
 end

--- a/app/models/fhir_record.rb
+++ b/app/models/fhir_record.rb
@@ -34,6 +34,6 @@ class FHIRRecord < ApplicationRecord
 
   def set_fhir_id
     json.id = id
-    save
+    save!
   end
 end

--- a/app/models/immunization.rb
+++ b/app/models/immunization.rb
@@ -41,12 +41,13 @@ class Immunization < FHIRRecord
   end
 
   def patient_id=(pid)
-    update_patient_reference(pid)
+    pat = Patient.find(pid) if pid
+    update_patient_reference(pat)
     super(pid)
   end
 
   def patient=(pat)
-    update_patient_reference(pat.id)
+    update_patient_reference(pat)
     super(pat)
   end
 
@@ -68,8 +69,12 @@ class Immunization < FHIRRecord
     json.vaccineCode.coding[0] = FHIR::Coding.new(system: 'http://hl7.org/fhir/sid/cvx', code: code)
   end
 
-  def update_patient_reference(pid)
-    json.patient ||= FHIR::Reference.new
-    json.patient.reference = "Patient/#{pid}"
+  def update_patient_reference(pat)
+    if pat
+      json.patient ||= FHIR::Reference.new
+      json.patient.reference = "Patient/#{pat.json.id}"
+    else
+      json.patient = nil
+    end
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -125,11 +125,10 @@ class Patient < FHIRRecord
 
   def to_bundle(base_url)
     bundle = FHIR::Bundle.new
-    patient_url = "#{base_url}/Patient/#{id}"
+    patient_url = "#{base_url}/Patient/#{json.id}"
     bundle.entry[0] = FHIR::Bundle::Entry.new(fullUrl: patient_url, resource: json)
     immunizations.each do |imm|
-      imm.json.patient.reference = patient_url
-      bundle.entry << FHIR::Bundle::Entry.new(fullUrl: "#{base_url}/Immunization/#{imm.id}", resource: imm.json)
+      bundle.entry << FHIR::Bundle::Entry.new(fullUrl: "#{base_url}/Immunization/#{imm.json.id}", resource: imm.json)
     end
     bundle
   end

--- a/db/migrate/20210428145300_add_id_to_fhir_json.rb
+++ b/db/migrate/20210428145300_add_id_to_fhir_json.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Sets ID in existing FHIR-based records
+class AddIdToFHIRJson < ActiveRecord::Migration[6.1]
+  def change
+    Patient.all.each { |pat| pat.set_fhir_id }
+    Immunization.all.each { |imm| imm.set_fhir_id }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_15_205132) do
+ActiveRecord::Schema.define(version: 2021_04_28_145300) do
 
   create_table "immunizations", force: :cascade do |t|
     t.integer "patient_id"

--- a/lib/health_cards/exceptions.rb
+++ b/lib/health_cards/exceptions.rb
@@ -35,4 +35,11 @@ module HealthCards
       super("Expected an instance of #{expected_class} but was #{actual_obj.class}")
     end
   end
+
+  # Exception thrown when a reference in a bundle in unresolvable
+  class InvalidBundleReferenceException < ArgumentError
+    def initialize(url)
+      super("Unable to resolve url (#{url}) within bundle")
+    end
+  end
 end

--- a/lib/health_cards/health_card.rb
+++ b/lib/health_cards/health_card.rb
@@ -183,32 +183,28 @@ module HealthCards
 
     def process_url(url)
       new_url = @url_map.key?(url) ? @url_map[url] : @url_map["#{issuer}/#{url}"]
-      raise InvalidBundleReferenceException, url unless new_url
+      raise InvalidBundleReferenceException(url) unless new_url
 
       new_url
     end
 
-    def update_nested_elements(hash) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-      hash.each do |k, v|
-        if v.is_a?(Hash) && (k.include?('CodeableConcept') || v.key?('coding'))
-          v.delete('text')
-        elsif k == 'coding'
-          # byebug
-          v.each do |coding|
-            coding.delete('display')
-          end
-        elsif k == 'reference'
-          hash[k] = process_url(v)
-        end
+    def update_nested_elements(hash)
+      hash.map { |k, v| update_nested_element(hash, k, v) }
+    end
 
-        case v
-        when Hash
-          update_nested_elements(v)
-        when Array
-          v.each { |x| update_nested_elements(x) if x.is_a?(Hash) }
+    def update_nested_element(hash, attribute_name, value) # rubocop:disable Metrics/CyclomaticComplexity
+      case value
+      when String
+        hash[attribute_name] = process_url(value) if attribute_name == 'reference'
+      when Hash
+        value.delete('text') if attribute_name.include?('CodeableConcept') || value.key?('coding')
+        update_nested_elements(value)
+      when Array
+        value.each do |member_element|
+          member_element.delete('display') if attribute_name == 'coding'
+          update_nested_elements(member_element) if member_element.is_a?(Hash)
         end
       end
-      hash
     end
   end
 end

--- a/test/fixtures/files/example-logical-link-bundle.json
+++ b/test/fixtures/files/example-logical-link-bundle.json
@@ -1,0 +1,106 @@
+{
+  "resourceType": "Bundle",
+  "id": "bundle-references",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "http://example.org/fhir/Patient/23",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "23",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 23</p><p><b>identifier</b>: 1234567</p></div>"
+        },
+        "identifier": [
+          {
+            "system": "http://example.org/ids",
+            "value": "1234567"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d",
+      "resource": {
+        "resourceType": "Patient",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p></div>"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://example.org/fhir/Observation/123",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "123",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 123</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p><p><b>subject</b>: <a>Patient/23</a></p></div>"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "15074-8",
+              "display": "Glucose [Moles/volume] in Blood"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/23"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://example.org/fhir/Observation/124",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "124",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 124</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p><p><b>subject</b>: <a>http://example.org/fhir/Patient/23</a></p></div>"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "15074-8",
+              "display": "Glucose [Moles/volume] in Blood"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "http://example.org/fhir/Patient/23"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://example.org/fhir/Observation/12",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "12",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 12</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p><p><b>subject</b>: <a>urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d</a></p></div>"
+        },
+        "status": "final",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "15074-8",
+              "display": "Glucose [Moles/volume] in Blood"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d"
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/files/example-logical-link-bundle.json
+++ b/test/fixtures/files/example-logical-link-bundle.json
@@ -7,27 +7,13 @@
       "fullUrl": "http://example.org/fhir/Patient/23",
       "resource": {
         "resourceType": "Patient",
-        "id": "23",
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 23</p><p><b>identifier</b>: 1234567</p></div>"
-        },
-        "identifier": [
-          {
-            "system": "http://example.org/ids",
-            "value": "1234567"
-          }
-        ]
+        "id": "23"
       }
     },
     {
       "fullUrl": "urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d",
       "resource": {
-        "resourceType": "Patient",
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p></div>"
-        }
+        "resourceType": "Patient"
       }
     },
     {
@@ -35,10 +21,6 @@
       "resource": {
         "resourceType": "Observation",
         "id": "123",
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 123</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p><p><b>subject</b>: <a>Patient/23</a></p></div>"
-        },
         "status": "final",
         "code": {
           "coding": [
@@ -59,10 +41,6 @@
       "resource": {
         "resourceType": "Observation",
         "id": "124",
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 124</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p><p><b>subject</b>: <a>http://example.org/fhir/Patient/23</a></p></div>"
-        },
         "status": "final",
         "code": {
           "coding": [
@@ -83,10 +61,6 @@
       "resource": {
         "resourceType": "Observation",
         "id": "12",
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: 12</p><p><b>status</b>: final</p><p><b>code</b>: Glucose [Moles/volume] in Blood <span>(Details : {LOINC code '15074-8' = 'Glucose [Moles/volume] in Blood', given as 'Glucose [Moles/volume] in Blood'})</span></p><p><b>subject</b>: <a>urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d</a></p></div>"
-        },
         "status": "final",
         "code": {
           "coding": [

--- a/test/health_cards/covid_health_card_test.rb
+++ b/test/health_cards/covid_health_card_test.rb
@@ -45,11 +45,11 @@ class COVIDHealthCardTest < ActiveSupport::TestCase
     end
   end
 
-  # test 'bundle json' do
-  #   assert_nothing_raised do
-  #     FHIR.from_contents(@card.to_json)
-  #   end
-  # end
+  test 'valid bundle json' do
+    assert_nothing_raised do
+      FHIR.from_contents(@card.to_json)
+    end
+  end
 
   test 'minified entries' do
     bundle = @card.strip_fhir_bundle

--- a/test/health_cards/health_card_test.rb
+++ b/test/health_cards/health_card_test.rb
@@ -128,6 +128,18 @@ class HealthCardTest < ActiveSupport::TestCase
     assert(reference.start_with?('resource:') && (reference.length <= 12))
   end
 
+  test 'all reference types are replaced with short resource-scheme URIs' do
+    bundle = FHIR::Bundle.new(load_json_fixture('example-logical-link-bundle'))
+    card = HealthCards::HealthCard.new(issuer: 'http://example.org/fhir', bundle: bundle)
+    assert_nothing_raised do
+      new_bundle = FHIR::Bundle.new(card.strip_fhir_bundle)
+
+      assert_entry_references_match(new_bundle.entry[0], new_bundle.entry[2].resource.subject) # logical ref
+      assert_entry_references_match(new_bundle.entry[0], new_bundle.entry[3].resource.subject) # full url ref
+      assert_entry_references_match(new_bundle.entry[1], new_bundle.entry[4].resource.subject) # uuid ref
+    end
+  end
+
   test 'compress_payload applies a raw deflate compression and allows for the original payload to be restored' do
     original_hc = HealthCards::HealthCard.new(issuer: @issuer, bundle: FHIR::Bundle.new)
     new_hc = HealthCards::HealthCard.from_payload(original_hc.to_s)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,5 +67,13 @@ module ActiveSupport
       bundle.entry << FHIR::Bundle::Entry.new(resource: FHIR::Patient.new)
       bundle
     end
+
+    def assert_entry_references_match(patient_entry, reference_element)
+      patient_url = patient_entry.fullUrl
+      ref_url = reference_element.reference
+
+      assert_not_nil patient_url
+      assert_equal patient_url, ref_url
+    end
   end
 end


### PR DESCRIPTION
Key Changes/Features
* Assigns ids to the FHIR JSON in our database which weren't there before. This id matches the database id. There is a migration that will need to be run for existing records to insert the id.
* Our reference processing will now handle logical references (e.g. Patient/1 -> http://example.org/Patient/1) provided urls are relative to the issuer url contained in the HealthCard
* If our bundle processing can't resolve a reference within a bundle it will now throw an exception as it is expected that all references resolve within the bundle.
* Cleaned up the Bundle tree walking code to remove Rubocop Perceived Complexity warning. Cyclomatic Complexity is lowered but still higher than default Rubocop setting.