### PR TITLE
Update Migration

### DIFF
--- a/db/migrate/20210428145300_add_id_to_fhir_json.rb
+++ b/db/migrate/20210428145300_add_id_to_fhir_json.rb
@@ -1,28 +1,38 @@
 # frozen_string_literal: true
 
+
 # Sets ID in existing FHIR-based records
 class AddIdToFHIRJson < ActiveRecord::Migration[6.1]
   # https://guides.rubyonrails.org/v4.1/migrations.html#using-models-in-your-migrations
   # https://rails.rubystyle.guide/#define-model-class-migrations
+  #
+  class MigrationFHIRSerializer
+    def self.load(json)
+      json ? FHIR.from_contents(json) : new
+    end
 
-  class MigrationPatient < ActiveRecord::Base
-    self.table_name = :patients
-    serialize :json, JSON
+    def self.dump(model)
+      raise ActiveRecord::SerializationTypeMismatch unless model.class.module_parent == FHIR
+
+      model.to_json
+    end
+  end
+
+  class MigrateFHIRRecord
+    serialize :json, MigrationFHIRSerializer
 
     def set_fhir_id
-      json['id'] = id
+      json.id = id
       save!
     end
   end
 
-  class MigrationImmunization < ActiveRecord::Base
-    self.table_name = :immunizations
-    serialize :json, JSON
+  class MigrationPatient < MigrateFHIRRecord
+    self.table_name = :patients
+  end
 
-    def set_fhir_id
-      json['id'] = id
-      save!
-    end
+  class MigrationImmunization < MigrateFHIRRecord
+    self.table_name = :immunizations
   end
 
   def change

--- a/db/migrate/20210428145300_add_id_to_fhir_json.rb
+++ b/db/migrate/20210428145300_add_id_to_fhir_json.rb
@@ -2,8 +2,27 @@
 
 # Sets ID in existing FHIR-based records
 class AddIdToFHIRJson < ActiveRecord::Migration[6.1]
+  # https://guides.rubyonrails.org/v4.1/migrations.html#using-models-in-your-migrations
+  # https://rails.rubystyle.guide/#define-model-class-migrations
+
+  class MigrationPatient < ActiveRecord::Base
+    self.table_name = :patients
+    def set_fhir_id
+      json.id = id
+      save!
+    end
+  end
+
+  class MigrationImmunization < ActiveRecord::Base
+    self.table_name = :immunizations
+    def set_fhir_id
+      json.id = id
+      save!
+    end
+  end
+
   def change
-    Patient.all.each { |pat| pat.set_fhir_id }
-    Immunization.all.each { |imm| imm.set_fhir_id }
+    MigrationPatient.all.each { |pat| pat.set_fhir_id }
+    MigrationImmunization.all.each { |imm| imm.set_fhir_id }
   end
 end

--- a/db/migrate/20210428145300_add_id_to_fhir_json.rb
+++ b/db/migrate/20210428145300_add_id_to_fhir_json.rb
@@ -7,16 +7,20 @@ class AddIdToFHIRJson < ActiveRecord::Migration[6.1]
 
   class MigrationPatient < ActiveRecord::Base
     self.table_name = :patients
+    serialize :json, JSON
+
     def set_fhir_id
-      json.id = id
+      json['id'] = id
       save!
     end
   end
 
   class MigrationImmunization < ActiveRecord::Base
     self.table_name = :immunizations
+    serialize :json, JSON
+
     def set_fhir_id
-      json.id = id
+      json['id'] = id
       save!
     end
   end

--- a/db/migrate/20210428145300_add_id_to_fhir_json.rb
+++ b/db/migrate/20210428145300_add_id_to_fhir_json.rb
@@ -18,7 +18,7 @@ class AddIdToFHIRJson < ActiveRecord::Migration[6.1]
     end
   end
 
-  class MigrateFHIRRecord
+  class MigrateFHIRRecord < ActiveRecord::Base
     serialize :json, MigrationFHIRSerializer
 
     def set_fhir_id


### PR DESCRIPTION
Right now the `AddIdToFHIRJson` is broken because it tries to use the protected `set_fhir_id` method. This PR fixes that issue by defining new migration specific models to use.

See [Rails Style Guide Define Model Class](https://rails.rubystyle.guide/#define-model-class-migrations) and [Ruby on Rails Using Models in Migrations](https://guides.rubyonrails.org/v4.1/migrations.html#using-models-in-your-migrations)

Side Note: Interestingly the [new Rails Guide doesn't have a section on using models in migrations](https://guides.rubyonrails.org/active_record_migrations.html). Is it better to use straight up SQL here?