### PR TITLE
Disable authenticity token check on FHIR post

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  private
+
+  def set_cors_header
+    response.header['Access-Control-Allow-Origin'] = '*'
+  end
 end

--- a/app/controllers/health_cards_controller.rb
+++ b/app/controllers/health_cards_controller.rb
@@ -5,11 +5,17 @@
 # HealthCardsController is the endpoint for download and issue of health cards
 class HealthCardsController < ApplicationController
   before_action :create_exporter, except: [:scan, :qr_contents, :upload]
-  skip_before_action :verify_authenticity_token, only: [:show]
+  skip_before_action :verify_authenticity_token, only: [:create]
+  after_action :set_cors_header, only: :create
 
   def show
     respond_to do |format|
       format.healthcard { render json: @exporter.download }
+    end
+  end
+
+  def create
+    respond_to do |format|
       format.fhir_json do
         fhir_params = FHIR.from_contents(request.raw_post)
         render json: @exporter.issue(fhir_params)

--- a/app/controllers/health_cards_controller.rb
+++ b/app/controllers/health_cards_controller.rb
@@ -5,6 +5,7 @@
 # HealthCardsController is the endpoint for download and issue of health cards
 class HealthCardsController < ApplicationController
   before_action :create_exporter, except: [:scan, :qr_contents, :upload]
+  skip_before_action :verify_authenticity_token, only: [:show]
 
   def show
     respond_to do |format|

--- a/app/controllers/well_known_controller.rb
+++ b/app/controllers/well_known_controller.rb
@@ -4,6 +4,8 @@ require 'health_cards'
 
 # WellKnownController exposes the .well-known configuration to identify relevant urls and server capabilities
 class WellKnownController < ApplicationController
+  after_action :set_cors_header
+
   def smart
     render json: Rails.application.config.smart
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
     end
   end
 
-  post '/Patient/:patient_id/$health-cards-issue', to: 'health_cards#show', as: :issue_vc, format: :fhir_json
+  post '/Patient/:patient_id/$health-cards-issue', to: 'health_cards#create', as: :issue_vc, format: :fhir_json
   get "/Patient/:id", to: "patients#show", as: :fhir_patient, format: :fhir_json
   get "/Immunization/:id", to: "immunizations#show", as: :fhir_immunization, format: :fhir_json
   get "/.well-known/smart-configuration", to: "well_known#smart", as: :well_known_smart, format: :json

--- a/test/controllers/health_cards_controller_test.rb
+++ b/test/controllers/health_cards_controller_test.rb
@@ -49,6 +49,8 @@ class HealthCardsControllerTest < ActionDispatch::IntegrationTest
 
     post(@fhir_url, params: params.to_hash, as: :json)
 
+    assert response['Access-Control-Allow-Origin'], '*'
+
     output = FHIR.from_contents(response.body)
 
     assert output.is_a?(FHIR::Parameters)

--- a/test/controllers/well_known_controller_test.rb
+++ b/test/controllers/well_known_controller_test.rb
@@ -17,6 +17,7 @@ class WellKnownControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     config = JSON.parse(response.body)
+    assert response['Access-Control-Allow-Origin'], '*'
     assert_equal @well_known, config.symbolize_keys
   end
 
@@ -33,6 +34,7 @@ class WellKnownControllerTest < ActionDispatch::IntegrationTest
       assert_equal val.to_s, response_key[att.to_s]
     end
 
+    assert response['Access-Control-Allow-Origin'], '*'
     assert_not response_key.key?('d')
   end
 end


### PR DESCRIPTION
The FHIR operation isn't a form post, so it can't use an authenticity token.