### PR TITLE
Fix gemspec

### DIFF
--- a/health_cards.gemspec
+++ b/health_cards.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/dvci/health_cards'
   spec.metadata['changelog_uri'] = 'https://github.com/dvci/health_cards/CHANGELOG.md'
-  spec.files = ['lib/health_cards.rb'] + Dir['/lib/health_cards/**/*']
+  spec.files = ['lib/health_cards.rb', 'LICENSE.txt'] + Dir['lib/health_cards/**/*']
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/lib/health_cards/verification.rb
+++ b/lib/health_cards/verification.rb
@@ -9,7 +9,7 @@ module HealthCards
     # @param key_set [HealthCards::KeySet, nil] the KeySet from which keys should be taken or added
     # @param resolve_keys [Boolean] if keys should be resolved
     # @return [Boolean]
-    def verify_using_key_set(verifiable, key_set = nil, resolve_keys = true)
+    def verify_using_key_set(verifiable, key_set = nil, resolve_keys: true)
       jws = JWS.from_jws(verifiable)
       key_set ||= HealthCards::KeySet.new
       key_set.add_keys(resolve_key(jws)) if resolve_keys && key_set.find_key(jws.kid).nil?

--- a/lib/health_cards/verifier.rb
+++ b/lib/health_cards/verifier.rb
@@ -58,7 +58,7 @@ module HealthCards
     # @param verifiable [HealthCards::JWS, String] the health card to verify
     # @return [Boolean]
     def verify(verifiable)
-      verify_using_key_set(verifiable, keys, resolve_keys?)
+      verify_using_key_set(verifiable, keys, resolve_keys: resolve_keys?)
     end
 
     def resolve_keys?


### PR DESCRIPTION
TL;DR: The current gemspec doesn't include all the files for the health cards gem.

Shout out to @Jammjammjamm for finding the gemspec issue here.

https://github.com/dvci/health_cards/commit/5300cbf3674ee8b2cc4f8a20e18a87ec5de1ded9 Updates the gemspec to properly include all the `'lib/health_cards/**/*'` files that should be in the gem.

https://github.com/dvci/health_cards/commit/c359a075e43552d769514ad8ffd8e3563f68cf32 is a small rider that fixes a rubocop issue which wanted the `resolve_keys` argument of `HealthCards::Verification#verify_using_key_set` to be a named keyword argument.

The gem can be built with `gem build health_cards.gemspec`

You can then [open up the gem to check the contents (it's just an uncompressed tar archive)](https://stackoverflow.com/questions/21824794/unpack-a-ruby-gem-without-gem-unpack-available).

[Rubygems also recommends doing a quick smoke test](https://guides.rubygems.org/make-your-own-gem/) after creating the gem (which worked for me!)

e.g. 

```
gem install health_cards-0.0.1.gem
irb
```

Then in the irb console:
```ruby
require 'health_cards'
HealthCards::Verifier.verify('eyJ6aXAiOiJERUYiLCJhbGciOiJFUzI1NiIsImtpZCI6IjNLZmRnLVh3UC03Z1h5eXd0VWZVQUR3QnVtRE9QS01ReC1pRUxMMTFXOXMifQ.3ZJLb9swEIT_SrC9yno1rSzd4hTo41AUaJpL4QNNrS0WfAgkJcQN9N-7SztAC8Q59RTdVhx-nBnyEVQI0MEQ4xi6oghG-Dig0HHIp
fB9KPBBmFFjKEg4oYcM7G4PXfW-LtfXTbtu8_XbJoNZQvcI8TgidD8v496chhUPhLqsU8ZMVv0WUTn7olC6WfVVC9sMpMcebVRCf592v1BGtrQflL9HH5jTwXVe5hXx-O9msr1G1ngMbvIS75J9OC9k5zggndZEOzmhA_yRMhJ50vqH1yR42t-VJHgangF_ozi0nzsUBk8QYZQmHtxY0viQzjioGS33-MUNPG9y2C4UcKco_AcRmVW176pVWa3q
EpYle9ZN9bKbz_9WHKKIU0hx-cIj8gXNQkpl8db1iSBdr-whGQ_HENGcnw7dzKCb3PlDwc0WQfWFnB8IINNOqMsGlu2SwXiuINnZo0fL3v5ukEROysmnJQ57p8wJUafAJceiqvbOG3qP7EXI6DwjexVGLVKdm9urj2jRC331yYVRRaGpKCpRu_h1MjveCmX6qosN1q-ywbr93w02vLDQ9wc.EReduRL4-W_FcGNbktsfn1H5FX8DJUE1pdAAJTG
1gSw7LSoCrhesJ25-rKhuOsDyo1gvOkqvzS_ZugpLi7t3Xg')
```