### PR TITLE
Fix fhirVersion null.

### DIFF
--- a/app/lib/covid_health_card_exporter.rb
+++ b/app/lib/covid_health_card_exporter.rb
@@ -32,7 +32,7 @@ class COVIDHealthCardExporter
 
   def jws
     issuer = Rails.application.config.issuer
-    @jws ||= issuer.issue_jws(@patient.to_bundle(issuer.url))
+    @jws ||= issuer.issue_jws(@patient.to_bundle(issuer.url), type: HealthCards::COVIDHealthCard)
   end
 
   def validate_fhir_params(fhir_params)


### PR DESCRIPTION
Specify `COVIDHealthCard` type when issuing jws which sets `fhir_version` to `4.0.1`