### PR TITLE
Use FHIR Metadata when minifying bundles

### DIFF
--- a/lib/health_cards/health_card.rb
+++ b/lib/health_cards/health_card.rb
@@ -144,7 +144,7 @@ module HealthCards
           type: self.class.types,
           credentialSubject: {
             fhirVersion: self.class.fhir_version,
-            fhirBundle: strip_fhir_bundle
+            fhirBundle: strip_fhir_bundle.to_hash
           }
         }
 

--- a/lib/health_cards/health_card.rb
+++ b/lib/health_cards/health_card.rb
@@ -84,7 +84,6 @@ module HealthCards
       def allow(klass, attributes)
         allowable[klass] = attributes
 
-        # keys.map ( key.is_a? klass)
       end
 
       # Define disallowed attributes for this HealthCard class

--- a/lib/health_cards/health_card.rb
+++ b/lib/health_cards/health_card.rb
@@ -147,7 +147,7 @@ module HealthCards
       protected
 
       def parent_allowables(base = {})
-        self < HealthCards::HealthCard ? superclass.parent_allowables(base.merge(superclass.allowable)) : base
+        self < HealthCards::HealthCard ? base.merge(superclass.allowable) : base
       end
 
       def parent_disallowables(base = {})

--- a/lib/health_cards/health_card.rb
+++ b/lib/health_cards/health_card.rb
@@ -151,7 +151,7 @@ module HealthCards
       end
 
       def parent_disallowables(base = {})
-        self < HealthCards::HealthCard ? superclass.parent_disallowables(base.merge(superclass.disallowable)) : base
+        self < HealthCards::HealthCard ? base.merge(superclass.disallowable) : base
       end
     end
 

--- a/test/health_cards/covid_health_card_test.rb
+++ b/test/health_cards/covid_health_card_test.rb
@@ -54,9 +54,9 @@ class COVIDHealthCardTest < ActiveSupport::TestCase
 
   test 'minified entries' do
     bundle = @card.strip_fhir_bundle
-    assert_equal 3, bundle['entry'].size
-    patient = FHIR::Patient.new(bundle['entry'][0]['resource'])
-    imm = FHIR::Immunization.new(bundle['entry'][1]['resource'])
+    assert_equal 3, bundle.entry.size
+    patient = bundle.entry[0].resource
+    imm = bundle.entry[1].resource
 
     assert_equal 'Jane', patient.name.first.given.first
     assert_equal '1961-01-20', patient.birthDate

--- a/test/health_cards/health_card_test.rb
+++ b/test/health_cards/health_card_test.rb
@@ -21,10 +21,6 @@ class HealthCardTest < ActiveSupport::TestCase
     assert @health_card.bundle.is_a?(FHIR::Bundle)
   end
 
-  # test "metadata walking" do
-  #   byebug
-  # end
-
   test 'HealthCard handles empty payloads' do
     compressed_payload = HealthCards::HealthCard.compress_payload(FHIR::Bundle.new.to_json)
     jws = HealthCards::JWS.new(header: {}, payload: compressed_payload, key: rails_private_key)
@@ -151,7 +147,8 @@ class HealthCardTest < ActiveSupport::TestCase
     resource_with_reference = stripped_resources[2]
 
     reference = resource_with_reference.resource.subject.reference
-    assert(reference.start_with?('resource:') && (reference.length <= 12))
+
+    assert_match(/resource:[0-9]+/, reference)
   end
 
   test 'all reference types are replaced with short resource-scheme URIs' do

--- a/test/health_cards/health_card_test.rb
+++ b/test/health_cards/health_card_test.rb
@@ -101,7 +101,7 @@ class HealthCardTest < ActiveSupport::TestCase
 
   test 'changes to stripped bundle do not affect bundle values' do
     stripped_bundle = @health_card.strip_fhir_bundle
-    
+
     # Check bundle
     stripped_bundle.type = 'foobar'
     assert_not_equal @health_card.bundle.type, stripped_bundle.type
@@ -109,7 +109,8 @@ class HealthCardTest < ActiveSupport::TestCase
     # Check entry value
     patient = stripped_bundle.entry[0].resource
     patient.name[0].family = 'foobar'
-    assert_not_equal @health_card.bundle.entry[0].resource.name[0].family, stripped_bundle.entry[0].resource.name[0].family
+    assert_not_equal @health_card.bundle.entry[0].resource.name[0].family,
+                     stripped_bundle.entry[0].resource.name[0].family
 
     # Check entries
     stripped_bundle.entry = []

--- a/test/health_cards/health_card_test.rb
+++ b/test/health_cards/health_card_test.rb
@@ -99,6 +99,23 @@ class HealthCardTest < ActiveSupport::TestCase
     assert_equal(resource_nums, inc_array)
   end
 
+  test 'changes to stripped bundle do not affect bundle values' do
+    stripped_bundle = @health_card.strip_fhir_bundle
+    
+    # Check bundle
+    stripped_bundle.type = 'foobar'
+    assert_not_equal @health_card.bundle.type, stripped_bundle.type
+
+    # Check entry value
+    patient = stripped_bundle.entry[0].resource
+    patient.name[0].family = 'foobar'
+    assert_not_equal @health_card.bundle.entry[0].resource.name[0].family, stripped_bundle.entry[0].resource.name[0].family
+
+    # Check entries
+    stripped_bundle.entry = []
+    assert_not_equal @health_card.bundle.entry.length, stripped_bundle.entry.length
+  end
+
   test 'update_elements strips resource-level "id", "meta", and "text" elements from the FHIR Bundle' do
     stripped_bundle = @health_card.strip_fhir_bundle
     stripped_entries = stripped_bundle.entry

--- a/test/health_cards/health_card_test.rb
+++ b/test/health_cards/health_card_test.rb
@@ -96,21 +96,10 @@ class HealthCardTest < ActiveSupport::TestCase
   end
 
   test 'changes to stripped bundle do not affect bundle values' do
-    stripped_bundle = @health_card.strip_fhir_bundle
-
-    # Check bundle
-    stripped_bundle.type = 'foobar'
-    assert_not_equal @health_card.bundle.type, stripped_bundle.type
-
-    # Check entry value
-    patient = stripped_bundle.entry[0].resource
-    patient.name[0].family = 'foobar'
-    assert_not_equal @health_card.bundle.entry[0].resource.name[0].family,
-                     stripped_bundle.entry[0].resource.name[0].family
-
-    # Check entries
-    stripped_bundle.entry = []
-    assert_not_equal @health_card.bundle.entry.length, stripped_bundle.entry.length
+    original_json = @health_card.to_json
+    @health_card.strip_fhir_bundle
+    original_json2 = @health_card.to_json
+    assert_equal original_json, original_json2
   end
 
   test 'update_elements strips resource-level "id", "meta", and "text" elements from the FHIR Bundle' do
@@ -119,8 +108,8 @@ class HealthCardTest < ActiveSupport::TestCase
 
     stripped_entries.each do |entry|
       resource = entry.resource
-      assert_not(resource.id)
-      assert_not(resource.text)
+      assert_not(resource.id, "#{resource} has id")
+      assert_not(resource.text, "#{resource} has text")
       meta = resource.meta
       if meta
         assert_equal 1, meta.to_hash.length

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -37,7 +37,7 @@ class PatientTest < ActiveSupport::TestCase
     hc = rails_issuer.create_health_card(bundle)
 
     assert_nothing_raised do
-      new_bundle = FHIR::Bundle.new(hc.strip_fhir_bundle)
+      new_bundle = hc.strip_fhir_bundle
 
       assert_entry_references_match(new_bundle.entry[0], new_bundle.entry[1].resource.patient)
     end


### PR DESCRIPTION
Refactor passes existing tests. Putting up as draft for sanity check review while I test new capabilities.

NOTE: This turns the stripped FHIR bundle into an actual FHIR::Bundle instead of a nested Hash.