### PR TITLE
nocov for random code

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -15,6 +15,7 @@ module PatientsHelper
     zip_code = Faker::Address.zip_code
     birth_date = Faker::Date.birthday(min_age: 16, max_age: 100)
     street_line2 = Faker::Address.secondary_address
+    # :nocov:
     given = case gender
             when 'male'
               Faker::Name.male_first_name
@@ -23,6 +24,7 @@ module PatientsHelper
             else
               Faker::Name.first_name
             end
+    # :nocov:
     { patient: { given: given, family: Faker::Name.last_name, gender: gender,
                  birth_date: birth_date, phone: phone, email: email, street_line1: street_line1,
                  street_line2: street_line2, city: city, state: state, zip_code: zip_code } }


### PR DESCRIPTION
Randomized code causes inconsistent coverage % reports in codecov. This excludes those lines to ensure consistency.