### PR TITLE
DVCI-120: Handle errors that occur when resolving keys

### DIFF
--- a/lib/health_cards/errors.rb
+++ b/lib/health_cards/errors.rb
@@ -23,6 +23,8 @@ module HealthCards
     end
   end
 
+  class UnresolvableKeySetError < JWSError; end
+
   # Errors related to HealthCard / Bundle
 
   # Exception thrown when an invalid payload is provided

--- a/lib/health_cards/importer.rb
+++ b/lib/health_cards/importer.rb
@@ -31,10 +31,11 @@ module HealthCards
       begin
         result[:verified] = Verifier.verify jws
         result[:error_message] = 'Signature Invalid' if result[:verified] == false
-      rescue MissingPublicKeyError
+      rescue MissingPublicKeyError, UnresolvableKeySetError => e
         result[:verified] = false
-        result[:error_message] = 'Cannot find public key'
+        result[:error_message] = e.message
       end
+
       result
     end
   end

--- a/lib/health_cards/verification.rb
+++ b/lib/health_cards/verification.rb
@@ -28,8 +28,12 @@ module HealthCards
     # @param jws [HealthCards::JWS, String] The JWS for which to resolve keys
     # @return [HealthCards::KeySet]
     def resolve_key(jws)
-      res = Net::HTTP.get(URI("#{HealthCard.from_jws(jws.to_s).issuer}/.well-known/jwks.json"))
+      jwks_uri = URI("#{HealthCard.from_jws(jws.to_s).issuer}/.well-known/jwks.json")
+      res = Net::HTTP.get(jwks_uri)
       HealthCards::KeySet.from_jwks(res)
+    # Handle response if key is malformed or unreachable
+    rescue StandardError => e
+      raise HealthCards::UnresolvableKeySetError, "Unable resolve a valid key from uri #{jwks_uri}: #{e.message}"
     end
   end
 end

--- a/test/controllers/health_cards_controller_test.rb
+++ b/test/controllers/health_cards_controller_test.rb
@@ -44,6 +44,21 @@ class HealthCardsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'upload file with no keys found' do
+    stub_request(:get, 'https://smarthealth.cards/examples/issuer/.well-known/jwks.json').to_return(body: nil,
+                                                                                                    status: 404)
+    file = fixture_file_upload('test/fixtures/files/example-00-e-file.smart-health-card')
+    post(upload_health_cards_path, params: { health_card: file })
+    assert_response :success
+  end
+
+  test 'upload file with keys timeout' do
+    stub_request(:get, 'https://smarthealth.cards/examples/issuer/.well-known/jwks.json').to_timeout
+    file = fixture_file_upload('test/fixtures/files/example-00-e-file.smart-health-card')
+    post(upload_health_cards_path, params: { health_card: file })
+    assert_response :success
+  end
+
   test 'issue smart card' do
     param = FHIR::Parameters::Parameter.new(name: 'credentialType',
                                             valueUri: 'https://smarthealth.cards#covid19')

--- a/test/health_cards/verifier_test.rb
+++ b/test/health_cards/verifier_test.rb
@@ -142,6 +142,22 @@ class VerifierTest < ActiveSupport::TestCase
     assert verifier.verify(@jws)
   end
 
+  test 'Verifier will raise an error if no valid key is found' do
+    stub_request(:get, /jwks.json/).to_return(status: 404)
+    verifier = HealthCards::Verifier
+    assert_raises HealthCards::UnresolvableKeySetError do
+      verifier.verify(@jws)
+    end
+  end
+
+  test 'Verifier will raise a HealthCard error if key resolution times out' do
+    stub_request(:get, /jwks.json/).to_timeout
+    verifier = HealthCards::Verifier
+    assert_raises HealthCards::UnresolvableKeySetError do
+      verifier.verify(@jws)
+    end
+  end
+
   test 'Verifier class will verify health cards when key is resolvable' do
     stub_request(:get, /jwks.json/).to_return(status: 200, body: @verifier.keys.to_jwk)
     verifier = HealthCards::Verifier


### PR DESCRIPTION
resolve_keys now raises a HealthCards specific error if there is an issue resolving or parsing the JWK set. This error is then handled by the Importer.

![Screen Shot 2021-06-25 at 9 51 53 AM](https://user-images.githubusercontent.com/7733/123435996-2ce8c980-d59c-11eb-9523-008b678daaf2.png)
