### PR TITLE
DVCI-134: Replace walk_resource with each_element

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'health_cards', path: '.'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
-gem 'fhir_models'
+gem 'fhir_models', '~> 4.2.0'
 gem 'bulma-rails', '~> 0.9'
 gem 'american_date'
 gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     codecov (0.5.2)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -107,17 +107,17 @@ GEM
     faker (2.17.0)
       i18n (>= 1.6, < 2)
     ffi (1.15.0)
-    fhir_models (4.1.1)
+    fhir_models (4.2.0)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
-      nokogiri (>= 1.10.4)
+      nokogiri (>= 1.11.4)
     font-awesome-rails (4.7.0.7)
       railties (>= 3.2, < 7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
@@ -135,11 +135,11 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
     mini_mime (1.0.3)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.7)
-    nokogiri (1.11.2)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     parallel (1.20.1)
@@ -299,7 +299,7 @@ DEPENDENCIES
   codecov
   dotenv-rails
   faker
-  fhir_models
+  fhir_models (~> 4.2.0)
   font-awesome-rails
   health_cards!
   jbuilder (~> 2.7)

--- a/lib/health_cards/health_card.rb
+++ b/lib/health_cards/health_card.rb
@@ -146,9 +146,9 @@ module HealthCards
       new_bundle = duplicate_bundle
       url_map = redefine_uris(new_bundle)
 
-      new_bundle.entry.map do |entry|
-        walk_resource(entry) do |value, type|
-          case type
+      new_bundle.entry.each do |entry|
+        entry.each_element do |value, metadata, _|
+          case metadata['type']
           when 'Reference'
             value.reference = process_reference(url_map, entry, value)
           when 'Resource'
@@ -158,7 +158,6 @@ module HealthCards
           handle_allowable(value)
           handle_disallowable(value)
         end
-        entry
       end
 
       new_bundle
@@ -181,20 +180,6 @@ module HealthCards
         resource_count += 1
       end
       url_map
-    end
-
-    def walk_resource(resource, &block)
-      resource.class::METADATA.each do |field_name, meta|
-        type = meta['type']
-        local_name = meta.fetch :local_name, field_name
-        values = [resource.instance_variable_get("@#{local_name}")].flatten.compact
-        next if values.empty?
-
-        values.each do |value|
-          yield value, type
-          walk_resource value, &block unless FHIR::PRIMITIVES.include? type
-        end
-      end
     end
 
     def process_reference(url_map, entry, ref)


### PR DESCRIPTION
We no longer need to implement `walk_resource` now that `fhir_models` has `each_element`.