### PR TITLE
Version 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
-# CHANGE LOG
+# Changelog
 
-## 0.0.2 - 2021-07-02
- - remove json-minify dependency
- - require fhir_models >= 4.0
+_Note: This changelog is tracking changes related to the `health_cards` library._
 
-## 0.0.1 - 2021-05-14
- - health_cards gem released
+## [v0.0.2](https://github.com/dvci/health_cards/tree/v0.0.2) (2021-07-09)
+- Added `fhir_models` >= 4.0 dependency [\#69](https://github.com/dvci/health_cards/pull/69)
+- Added native QR Code generation [\#62](https://github.com/dvci/health_cards/pull/62)
+- Updated FHIR Bundle minification [\#60](https://github.com/dvci/health_cards/pull/60)
+- Updated error handling [\#63](https://github.com/dvci/health_cards/pull/63)
+- Updated allowed/disallowed attributes implemenation [\#67](https://github.com/dvci/health_cards/pull/67)
+- Updated key resolution failure error handling [\#74](https://github.com/dvci/health_cards/pull/74)
+- Updated Bundle minification to use `each_element` [\#75](https://github.com/dvci/health_cards/pull/75)
+- Updated README [\#70](https://github.com/dvci/health_cards/pull/70)
+- Removed `json-minify` dependency [\#69](https://github.com/dvci/health_cards/pull/69)
+- Fixed `COVIDHealthCard` VC Type [\#56](https://github.com/dvci/health_cards/pull/56)
+
+## v0.0.1 (2021-05-14)
+ - Initial `health_cards` release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    health_cards (0.0.1)
+    health_cards (0.0.2)
       fhir_models (>= 4.0.0)
       rqrcode
 
@@ -200,7 +200,7 @@ GEM
     rqrcode (2.0.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
-    rqrcode_core (1.0.0)
+    rqrcode_core (1.1.0)
     rubocop (1.11.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)

--- a/lib/health_cards/version.rb
+++ b/lib/health_cards/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HealthCards
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end


### PR DESCRIPTION
* Bumps the version number in `version.rb` to 0.0.2
  * Updates version in the `Gemfile.lock` to 0.0.2.
* Updates the Changelog to reflect changes included in this release

Note: The Changelog release includes a link to the tagged commit associated with this release. Once this PR is merged the commit on `main` will be tagged with `v0.0.2` and (🤞) the link should work.