### PR TITLE
add vaccine codes for astra-zeneca, novavax, and unspecified

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,3 +19,14 @@ Vaccine.find_or_create_by(code: '212') do |vaccine|
   vaccine.name = 'Janssen COVID-19 Vaccine'
   vaccine.doses_required = 1
 end
+Vaccine.find_or_create_by(code: '210') do |vaccine|
+  vaccine.name = 'AstraZeneca COVID-19 Vaccine'
+  vaccine.doses_required = 1
+end
+Vaccine.find_or_create_by(code: '211') do |vaccine|
+  vaccine.name = 'Novavax COVID-19 Vaccine'
+  vaccine.doses_required = 1
+end
+Vaccine.find_or_create_by(code: '213') do |vaccine|
+  vaccine.name = 'Unspecified COVID-19 Vaccine'
+end


### PR DESCRIPTION
Just a quick update to database CVX vaccine codes I needed; not ticket worthy and if we are planning on refactoring vaccine codes into immunization then this is unnecessary:

 - add CVX 210 AstraZeneca COVID-19 Vaccine
 - add CVX 211 Novavax COVID-19 Vaccine
 - add CVX 213 Unspecified COVID-19 Vaccine

Note neither AstraZeneca nor Novavax have been approved for use within the US. CVX 213 is potentially useful for specifying other vaccines not acknowledged by US