### PR TITLE
Fix IG URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then go to `http://127.0.0.1:3000` to view the locally running application.
 
 Health Cards is a Ruby gem that implements [SMART Health Cards](https://smarthealth.cards), a framework for sharing verifiable clinical data with [HL7 FHIR](https://hl7.org/FHIR/) and [JSON Web Signatures (JWS)](https://datatracker.ietf.org/doc/html/rfc7515) which may then be embedded into a QR code, exported to a `*.smart-health-card` file, or returned by a `$health-card-issue` FHIR operation.
 
-This library also natively supports [SMART Health Cards: Vaccination & Testing Implementation Guide](http://hl7.org/fhir/uv/shc-vaccination/history.html) specific cards.
+This library also natively supports [SMART Health Cards: Vaccination & Testing Implementation Guide](https://vci.org/ig/vaccination-and-testing) specific cards.
 
 ### Installation
 


### PR DESCRIPTION
Github repo for the VCI IG was moved to HL7.  History page has link to correct build and to the version for HL7 Sept 2021 ballot.